### PR TITLE
Passing objects when selection changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.4
+
+- Selector onChange callback called with an object instead of id
+
 # 0.7.0
 
 - Borderless input fields

--- a/components/Selector.jsx
+++ b/components/Selector.jsx
@@ -10,15 +10,15 @@ export default function Selector (props) {
   const baseClass = 'cui__selector--direct'
   const cls = classNames(baseClass, 'title', className)
 
-  const options = data.map(({id, label}) => {
+  const options = data.map((d) => {
     const optionClass = classNames(`${baseClass}__item`)
     const labelClass = classNames(`${baseClass}__label`)
     const iconClass = classNames(`${baseClass}__icon`)
 
     return (
-      <div key={id} className={optionClass} onClick={() => onChange(id)}>
-        <div className={labelClass} style={{display: 'block'}}>{label}</div>
-        {id === selected ? <Checkmark className={iconClass} color='blue'/> : null}
+      <div key={d.id} className={optionClass} onClick={() => onChange(d)}>
+        <div className={labelClass} style={{display: 'block'}}>{d.label}</div>
+        {d.id === selected ? <Checkmark className={iconClass} color='blue'/> : null}
       </div>
     )
   })

--- a/example/Menus.jsx
+++ b/example/Menus.jsx
@@ -111,7 +111,6 @@ export default function Menus () {
         Animated menus must be controlled. On implementation reference can be found in examples/Menus.jsx.
       </Paragraph>
 
-
       <Subtitle>Fluid</Subtitle>
       <Paragraph>Click "Add" and check it out</Paragraph>
       <Code>
@@ -146,10 +145,6 @@ export default function Menus () {
           options={options}
         />
       </Code>
-
-
-
-
 
       <Subtitle>Static</Subtitle>
       <Paragraph>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klarna/ui-react-components",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Klarna's UI React Components",
   "repository": "https://github.com/klarna/ui-react-components",
   "license": "SEE LICENSE IN LICENSE",

--- a/tests/Selector.spec.jsx
+++ b/tests/Selector.spec.jsx
@@ -45,9 +45,9 @@ describe('Selector', () => {
 
     it('calls onChange callback when options are clicked', () => {
       options[0].props.onClick()
-      ok(onChange.calledWith(1))
+      ok(onChange.calledWith(data[0]))
       options[1].props.onClick()
-      ok(onChange.calledWith(2))
+      ok(onChange.calledWith(data[1]))
     })
   })
 })


### PR DESCRIPTION
When changing selection in the Selector components it will now pass the object that corresponds to the selected option, instead of passing the ID only.

This is useful for doing
 ```jsx
const data = [{
  id: 1,
  payload: 'foo'
}, {
  id: 2,
  payload: 'bar'
}]
<Selector data={data} onChange={(obj) => console.log(obj.payload)}> 
```

