### PR TITLE
Set an explicit dependency on the latest css component 5.x.x release

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "author": "Klarna front end people",
   "dependencies": {
-    "@klarna/ui-css-components": "^5.6.5",
+    "@klarna/ui-css-components": "5.7.1",
     "classnames": "^2.1.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
I just had a nasty surprise when a regression snuck its way into Checkout. I couldn't reproduce the issue locally, and eventually I found out that it was because while I had a strict dependency on a specific version of the ui-react-components, the ui-react-components had a loose dependency on the ui-css-components. I had an older version of the ui-css-components installed, and Jenkins was getting the latest version.

I think the `ui-react-components` project should use strict dependencies, at least for dependencies that are actually shipped. It's not nice to surprise your consumers with new versions of dependencies without the consumers having actually bumped their dependencies.