### PR TITLE
Style overrides

### DIFF
--- a/components/Block.jsx
+++ b/components/Block.jsx
@@ -1,10 +1,9 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/block.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/block.scss'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function Block ({className, blue, children, ...remainingProps}) {
+export default function Block ({className, blue, children, styles, ...remainingProps}) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames('cui__block', { blue }, className)
 
   return (
@@ -17,5 +16,6 @@ export default function Block ({className, blue, children, ...remainingProps}) {
 Block.propTypes = {
   blue: PropTypes.bool,
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  styles: PropTypes.object
 }

--- a/components/Button.jsx
+++ b/components/Button.jsx
@@ -1,8 +1,6 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/button.scss'
-
-const classNames = classNamesBind.bind(styles)
+import defaultStyles from '@klarna/ui-css-components/src/components/button.scss'
 
 export default function Button (props) {
   const {
@@ -13,10 +11,13 @@ export default function Button (props) {
     size,
     success,
     disabled,
+    styles,
     ...remainingProps } = props
 
   const content =
     success && '✔' || !loading && children
+
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   const cls = classNames(`cui__button--${design}`, size, {
     'is-disabled': disabled,
@@ -47,5 +48,6 @@ Button.propTypes = {
   size: PropTypes.oneOf(Button.sizes),
   loading: PropTypes.bool,
   success: PropTypes.bool,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  styles: PropTypes.object
 }

--- a/components/Checklist.jsx
+++ b/components/Checklist.jsx
@@ -46,7 +46,7 @@ Checklist.Item.displayName = 'Checklist.Item'
 Checklist.Item.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
-  styles: PropTypes.obj
+  styles: PropTypes.object
 }
 
 Checklist.Item.defaultProps = {

--- a/components/Checklist.jsx
+++ b/components/Checklist.jsx
@@ -1,10 +1,10 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/checklist.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/checklist.scss'
 
-const classNames = classNamesBind.bind(styles)
+export default function Checklist ({ chromeless, className, children, styles }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
-export default function Checklist ({ chromeless, className, children }) {
   return (
     <ul
       className={classNames('cui__checklist', { chromeless }, className)}>
@@ -16,25 +16,39 @@ export default function Checklist ({ chromeless, className, children }) {
 Checklist.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
-  chromeless: PropTypes.bool
+  chromeless: PropTypes.bool,
+  styles: PropTypes.obj
 }
 
-Checklist.Item = ({ className, children }) => (
-  <li
-    className={classNames('cui__checklist__item', className)}>
-    <svg
-      className={classNames('cui__checklist__checkmark')}
-      viewBox='0 0 25 25'
-      ariaLabelledby='Checkmark'>
-      <path d='M5 13.69l4.49 4.23L19.37 8'></path>
-    </svg>
-    {children}
-  </li>
-)
+Checklist.defaultProps = {
+  styles: {}
+}
+
+Checklist.Item = ({ className, children, styles }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
+    <li
+      className={classNames('cui__checklist__item', className)}>
+      <svg
+        className={classNames('cui__checklist__checkmark')}
+        viewBox='0 0 25 25'
+        ariaLabelledby='Checkmark'>
+        <path d='M5 13.69l4.49 4.23L19.37 8'></path>
+      </svg>
+      {children}
+    </li>
+  )
+}
 
 Checklist.Item.displayName = 'Checklist.Item'
 
 Checklist.Item.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node
+  children: PropTypes.node,
+  styles: PropTypes.obj
+}
+
+Checklist.Item.defaultProps = {
+  styles: {}
 }

--- a/components/Checklist.jsx
+++ b/components/Checklist.jsx
@@ -17,7 +17,7 @@ Checklist.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
   chromeless: PropTypes.bool,
-  styles: PropTypes.obj
+  styles: PropTypes.object
 }
 
 Checklist.defaultProps = {

--- a/components/ContextMenu.jsx
+++ b/components/ContextMenu.jsx
@@ -1,54 +1,76 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/context-menu.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/context-menu.scss'
 
-const classNames = classNamesBind.bind(styles)
 const baseClass = 'cui__context-menu'
 
-const ContextMenu = ({ className, children, ...props }) => (
-  <ol className={classNames(baseClass, className)} {...props}>
-    {children}
-  </ol>
-)
+const ContextMenu = ({ className, children, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
-ContextMenu.Link = ({ className, children, ...props }) => (
-  <li>
-    <a className={classNames(`${baseClass}__item`, className)} {...props}>
+  return (
+    <ol className={classNames(baseClass, className)} {...props}>
       {children}
-    </a>
-  </li>
-)
+    </ol>
+  )
+}
+
+ContextMenu.Link = ({ className, children, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
+    <li>
+      <a className={classNames(`${baseClass}__item`, className)} {...props}>
+        {children}
+      </a>
+    </li>
+  )
+}
 ContextMenu.Link.displayName = 'ContextMenu.Link'
 
-ContextMenu.Item = ({ className, children, ...props }) => (
-  <li className={classNames(`${baseClass}__item`, className)} {...props}>
+ContextMenu.Item = ({ className, children, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
+    <li className={classNames(`${baseClass}__item`, className)} {...props}>
     {children}
-  </li>
-)
+    </li>
+  )
+}
 ContextMenu.Item.displayName = 'ContextMenu.Item'
 
 ContextMenu.propTypes = ContextMenu.Link.propTypes = ContextMenu.Item.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node
+  children: PropTypes.node,
+  styles: PropTypes.object
 }
 
-ContextMenu.Separator = ({ className, ...props }) => (
-  <li className={classNames(`${baseClass}__separator`, className)} {...props} />
-)
+ContextMenu.Separator = ({ className, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
+    <li className={classNames(`${baseClass}__separator`, className)} {...props} />
+  )
+}
 ContextMenu.Separator.displayName = 'ContextMenu.Separator'
 ContextMenu.Separator.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
+  styles: PropTypes.object
 }
 
-ContextMenu.Icon = ({ className, children }) => (
-  React.cloneElement(React.Children.only(children), {
-    className: classNames(`${baseClass}__icon`, className)
-  })
-)
+ContextMenu.Icon = ({ className, children, styles }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
+    React.cloneElement(React.Children.only(children), {
+      className: classNames(`${baseClass}__icon`, className)
+    })
+  )
+}
 ContextMenu.Icon.displayName = 'ContextMenu.Icon'
 ContextMenu.Icon.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.element
+  children: PropTypes.element,
+  styles: PropTypes.object
 }
 
 export default ContextMenu

--- a/components/Dialog.jsx
+++ b/components/Dialog.jsx
@@ -1,10 +1,10 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/dialog.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/dialog.scss'
 
-const classNames = classNamesBind.bind(styles)
+export default function Dialog ({ children, className, styles, ...props }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
-export default function Dialog ({ children, className, ...props }) {
   return (
     <div className={classNames('cui__dialog', className)} {...props}>
       {children}
@@ -14,66 +14,87 @@ export default function Dialog ({ children, className, ...props }) {
 
 Dialog.propTypes = {
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  styles: PropTypes.object
 }
 
-Dialog.Icon = ({ children, className, ...props }) => (
-  <div className={classNames('cui__dialog__icon', className)} {...props}>
-    {children}
-  </div>
-)
+Dialog.Icon = ({ children, className, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
+    <div className={classNames('cui__dialog__icon', className)} {...props}>
+      {children}
+    </div>
+  )
+}
 
 Dialog.Icon.propTypes = {
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  styles: PropTypes.object
 }
 
 Dialog.Icon.displayName = 'Dialog.Icon'
 
-Dialog.Content = ({ children, className, ...props }) => (
-  <div className={classNames('cui__dialog__content', className)} {...props}>
-    <div className={classNames('cui__dialog__content--inner')}>
-      {children}
+Dialog.Content = ({ children, className, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
+    <div className={classNames('cui__dialog__content', className)} {...props}>
+      <div className={classNames('cui__dialog__content--inner')}>
+        {children}
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 Dialog.Content.displayName = 'Dialog.Content'
 
 Dialog.Content.propTypes = {
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  styles: PropTypes.object
 }
 
-Dialog.Footer = ({ children, className, ...props }) => (
-  <div
-    className={classNames('cui__dialog__footer', className)} {...props}>
+Dialog.Footer = ({ children, className, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
     <div
-      className={classNames('cui__dialog__footer--inner')}>
-      {children}
+      className={classNames('cui__dialog__footer', className)} {...props}>
+      <div
+        className={classNames('cui__dialog__footer--inner')}>
+        {children}
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 Dialog.Footer.displayName = 'Dialog.Footer'
 
 Dialog.Footer.propTypes = {
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  styles: PropTypes.object
 }
 
-Dialog.Overlay = ({ children, className, show, ...props }) => (
-  <div
-    className={classNames('cui__dialog__overlay', { 'is-visible': show }, className)}>
+Dialog.Overlay = ({ children, className, show, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
     <div
-      className={classNames('cui__dialog__wrapper')}>
-      {children}
+      className={classNames('cui__dialog__overlay', { 'is-visible': show }, className)}>
+      <div
+        className={classNames('cui__dialog__wrapper')}>
+        {children}
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 Dialog.Overlay.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
-  show: PropTypes.bool
+  show: PropTypes.bool,
+  styles: PropTypes.object
 }

--- a/components/Field.jsx
+++ b/components/Field.jsx
@@ -1,13 +1,11 @@
 import React, { PropTypes, Component } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/field.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/field.scss'
 import * as programmaticFocus from '../lib/features/programmaticFocus'
 import * as fieldStates from '../lib/features/fieldStates'
 import * as inlinedIcon from '../lib/features/inlinedIcon'
 import { position, size } from '../lib/features/stacking'
 import { handleKeyDown } from '../lib/features/keyboardEvents'
-
-const classNames = classNamesBind.bind(styles)
 
 export default class Field extends Component {
 
@@ -34,8 +32,10 @@ export default class Field extends Component {
       onFocus,
       square,
       value,
+      styles,
       ...props
     } = this.props
+    const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
     const classes = {
       field: classNames(
@@ -115,6 +115,7 @@ Field.propTypes = {
   onClick: PropTypes.func,
   onFocus: PropTypes.func,
   value: PropTypes.string,
+  styles: PropTypes.object,
   ...inlinedIcon.propTypes,
   ...fieldStates.propTypes,
   ...handleKeyDown.propTypes,

--- a/components/Fieldset.jsx
+++ b/components/Fieldset.jsx
@@ -1,14 +1,14 @@
 import React, { PropTypes} from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/field.scss'
-
-const classNames = classNamesBind.bind(styles)
+import defaultStyles from '@klarna/ui-css-components/src/components/field.scss'
 
 export default function Fieldset (props) {
   const {
     className,
     children,
+    styles,
     ...remainingProps } = props
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   const cls = classNames('cui__fieldset', className)
 
@@ -19,5 +19,6 @@ export default function Fieldset (props) {
 
 Fieldset.propTypes = {
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  styles: PropTypes.object
 }

--- a/components/IconButton.jsx
+++ b/components/IconButton.jsx
@@ -1,84 +1,105 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/illustration.scss'
-
-const classNames = classNamesBind.bind(styles)
+import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 
 const iconPropTypes = {
   className: PropTypes.string,
-  color: PropTypes.oneOf(['gray', 'inverse'])
+  color: PropTypes.oneOf(['gray', 'inverse']),
+  styles: PropTypes.object
 }
 
-export const BackButton = ({ className, color, ...props }) => (
-  <svg
-    className={classNames('cui__illustration', 'button', color, className)}
-    strokeLinecap='round'
-    strokeWidth='2'
-    viewBox='0 0 25 25'
-    {...props}>
-    <path
-      className={classNames('cui__illustration__stroke')}
-      d='M15,6l-6.5,6.5l6.5,6.5'
-    />
-  </svg>
-)
+export const BackButton = ({ className, color, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
-export const CloseButton = ({ className, color, ...props }) => (
-  <svg
-    className={classNames('cui__illustration', 'button', color, className)}
-    strokeLinecap='round'
-    strokeWidth='2'
-    viewBox='0 0 25 25'
-    {...props}>
-    <line x1='6' x2='19' y1='6' y2='19' className={classNames('cui__illustration__stroke')} />
-    <line x1='19' x2='6' y1='6' y2='19' className={classNames('cui__illustration__stroke')} />
-  </svg>
-)
+  return (
+    <svg
+      className={classNames('cui__illustration', 'button', color, className)}
+      strokeLinecap='round'
+      strokeWidth='2'
+      viewBox='0 0 25 25'
+      {...props}>
+      <path
+        className={classNames('cui__illustration__stroke')}
+        d='M15,6l-6.5,6.5l6.5,6.5'
+      />
+    </svg>
+  )
+}
 
-export const HamburgerButton = ({ className, color, ...props }) => (
-  <svg
-    className={classNames('cui__illustration', 'button', color, className)}
-    viewBox='0 0 25 25'
-    strokeLinecap='round'
-    strokeWidth='2'
-    {...props}>
-    {[8, 13, 18].map((y) =>
+export const CloseButton = ({ className, color, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
+    <svg
+      className={classNames('cui__illustration', 'button', color, className)}
+      strokeLinecap='round'
+      strokeWidth='2'
+      viewBox='0 0 25 25'
+      {...props}>
+      <line x1='6' x2='19' y1='6' y2='19'
+        className={classNames('cui__illustration__stroke')} />
+      <line x1='19' x2='6' y1='6' y2='19'
+        className={classNames('cui__illustration__stroke')} />
+    </svg>
+  )
+}
+
+export const HamburgerButton = ({ className, color, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
+    <svg
+      className={classNames('cui__illustration', 'button', color, className)}
+      viewBox='0 0 25 25'
+      strokeLinecap='round'
+      strokeWidth='2'
+      {...props}>
+      {[8, 13, 18].map((y) =>
+        <line
+          className={classNames('cui__illustration__stroke')}
+          key={y} x1='6' x2='19' y1={y} y2={y}
+        />
+      )}
+    </svg>
+  )
+}
+
+export const OptionsButton = ({ className, color, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
+    <svg
+      className={classNames('cui__illustration', 'button', color, className)}
+      viewBox='0 0 25 25'
+      {...props}>
+      {[7, 13, 19].map((y) =>
+        <circle
+          className={classNames('cui__illustration__fill')}
+          key={y} cx='12' cy={y} r='2'
+        />
+      )}
+    </svg>
+  )
+}
+
+export const SearchButton = ({ className, color, styles, ...props }) => {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+
+  return (
+    <svg
+      className={classNames('cui__illustration', 'button', color, className)}
+      viewBox='0 0 25 25'
+      strokeWidth='2'
+      strokeLinecap='round'
+      {...props}>
+      <circle
+        className={classNames('cui__illustration__stroke')}
+        cx={10.5} cy={10.5} r={5.5} />
       <line
         className={classNames('cui__illustration__stroke')}
-        key={y} x1='6' x2='19' y1={y} y2={y}
-      />
-    )}
-  </svg>
-)
-
-export const OptionsButton = ({ className, color, ...props }) => (
-  <svg
-    className={classNames('cui__illustration', 'button', color, className)}
-    viewBox='0 0 25 25'
-    {...props}>
-    {[7, 13, 19].map((y) =>
-      <circle
-        className={classNames('cui__illustration__fill')}
-        key={y} cx='12' cy={y} r='2'
-      />
-    )}
-  </svg>
-)
-
-export const SearchButton = ({ className, color, ...props }) => (
-  <svg
-    className={classNames('cui__illustration', 'button', color, className)}
-    viewBox='0 0 25 25'
-    strokeWidth='2'
-    strokeLinecap='round'
-    {...props}>
-    <circle
-      className={classNames('cui__illustration__stroke')}
-      cx={10.5} cy={10.5} r={5.5} />
-    <line
-      className={classNames('cui__illustration__stroke')}
-      x1={15} x2={19.2} y1={15} y2={19.2} />
-  </svg>
-)
+        x1={15} x2={19.2} y1={15} y2={19.2} />
+    </svg>
+  )
+}
 
 BackButton.propTypes = CloseButton.propTypes = HamburgerButton.propTypes = OptionsButton.propTypes = SearchButton.propTypes = iconPropTypes

--- a/components/Input.jsx
+++ b/components/Input.jsx
@@ -1,13 +1,11 @@
 import React, { PropTypes, Component } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/input.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/input.scss'
 import * as programmaticFocus from '../lib/features/programmaticFocus'
 import * as fieldStates from '../lib/features/fieldStates'
 import * as inlinedIcon from '../lib/features/inlinedIcon'
 import { position, size } from '../lib/features/stacking'
 import { handleKeyDown } from '../lib/features/keyboardEvents'
-
-const classNames = classNamesBind.bind(styles)
 
 export default class Input extends Component {
 
@@ -35,8 +33,10 @@ export default class Input extends Component {
       onFocus,
       square,
       value,
+      styles,
       ...props
     } = this.props
+    const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
     const classes = {
       field: classNames(
@@ -119,6 +119,7 @@ Input.propTypes = {
   onClick: PropTypes.func,
   onFocus: PropTypes.func,
   value: PropTypes.string,
+  styles: PropTypes.object,
   ...inlinedIcon.propTypes,
   ...fieldStates.propTypes,
   ...handleKeyDown.propTypes,

--- a/components/Label.jsx
+++ b/components/Label.jsx
@@ -1,10 +1,17 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/label.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/label.scss'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function Label ({ children, className, design, outline, inverted, ...props }) {
+export default function Label ({
+  children,
+  className,
+  design,
+  outline,
+  inverted,
+  styles,
+  ...props
+}) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames('cui__label', design, className, {
     outline,
     inverted
@@ -36,5 +43,6 @@ Label.propTypes = {
   className: PropTypes.string,
   design: PropTypes.oneOf(Label.designs),
   inverted: PropTypes.bool,
-  outline: PropTypes.bool
+  outline: PropTypes.bool,
+  styles: PropTypes.object
 }

--- a/components/Link.jsx
+++ b/components/Link.jsx
@@ -1,11 +1,10 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/link.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/link.scss'
 import palette from './texts/palette'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function Link ({className, color, children, ...props}) {
+export default function Link ({className, color, children, styles, ...props}) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames('cui__link', color, className)
 
   return (
@@ -18,5 +17,6 @@ export default function Link ({className, color, children, ...props}) {
 Link.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
-  color: PropTypes.oneOf(palette)
+  color: PropTypes.oneOf(palette),
+  styles: PropTypes.object
 }

--- a/components/Loader.jsx
+++ b/components/Loader.jsx
@@ -1,10 +1,9 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/loader.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/loader.scss'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function Loader ({className, color, size}) {
+export default function Loader ({ className, color, size, styles }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames('cui__loader', size, color, className)
 
   return <div className={cls} />
@@ -16,5 +15,6 @@ Loader.colors = ['blue', 'white']
 Loader.propTypes = {
   className: PropTypes.string,
   color: PropTypes.oneOf(Loader.colors),
-  size: PropTypes.oneOf(Loader.sizes)
+  size: PropTypes.oneOf(Loader.sizes),
+  styles: PropTypes.object
 }

--- a/components/PayButton.jsx
+++ b/components/PayButton.jsx
@@ -17,7 +17,7 @@ export default function PayButton ({
   return (
     <Button className={cls} loading={loading} {...remainingProps}>
       {children}
-      <span className={styles['cui__button__price']}>
+      <span className={classNames('cui__button__price')}>
         {price}
       </span>
     </Button>

--- a/components/PayButton.jsx
+++ b/components/PayButton.jsx
@@ -1,12 +1,17 @@
 import React, { PropTypes } from 'react'
-import styles from '@klarna/ui-css-components/src/components/button.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/button.scss'
 import Button from './Button'
 import classNamesBind from 'classnames/bind'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function PayButton (props) {
-  const { price, children, className, loading, ...remainingProps } = props
+export default function PayButton ({
+  price,
+  children,
+  className,
+  loading,
+  styles,
+  ...remainingProps
+}) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames(loading || 'has-price', className)
 
   return (

--- a/components/Preview.jsx
+++ b/components/Preview.jsx
@@ -1,10 +1,9 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/preview.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/preview.scss'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function Preview ({ className, children }) {
+export default function Preview ({ className, children, styles }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames('cui__preview', className)
 
   return (
@@ -18,10 +17,12 @@ export default function Preview ({ className, children }) {
 
 Preview.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node
+  children: PropTypes.node,
+  styles: PropTypes.object
 }
 
-export function PreviewTitle ({ children, className }) {
+export function PreviewTitle ({ children, className, styles }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames('cui__preview__title', className)
 
   return (
@@ -33,15 +34,12 @@ export function PreviewTitle ({ children, className }) {
 
 PreviewTitle.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node
+  children: PropTypes.node,
+  styles: PropTypes.object
 }
 
-export function PreviewLink (props) {
-  const {
-    children,
-    className,
-    ...remainingProps } = props
-
+export function PreviewLink ({ children, className, styles, ...remainingProps }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames('cui__preview__footer__link', className)
 
   return (
@@ -55,5 +53,6 @@ export function PreviewLink (props) {
 
 PreviewLink.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node
+  children: PropTypes.node,
+  styles: PropTypes.object
 }

--- a/components/Preview.jsx
+++ b/components/Preview.jsx
@@ -8,7 +8,7 @@ export default function Preview ({ className, children, styles }) {
 
   return (
     <div className={cls}>
-      <div className={styles['cui__preview__content']}>
+      <div className={classNames('cui__preview__content')}>
         {children}
       </div>
     </div>
@@ -43,7 +43,7 @@ export function PreviewLink ({ children, className, styles, ...remainingProps })
   const cls = classNames('cui__preview__footer__link', className)
 
   return (
-    <div className={styles['cui__preview__footer']}>
+    <div className={classNames('cui__preview__footer')}>
       <a className={cls} {...remainingProps}>
         {children}
       </a>

--- a/components/RadioGroup.jsx
+++ b/components/RadioGroup.jsx
@@ -1,12 +1,11 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/dropdown.scss'
-
-const classNames = classNamesBind.bind(styles)
+import defaultStyles from '@klarna/ui-css-components/src/components/dropdown.scss'
 
 export default function RadioGroup (props) {
-  const { selected, onChange, className, data, ...remainingProps } = props
+  const { selected, onChange, className, data, styles, ...remainingProps } = props
   const baseClass = 'cui__dropdown--radio'
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames(baseClass, className)
 
   const options = data.map(({id, label, description}) => {
@@ -42,5 +41,6 @@ RadioGroup.propTypes = {
   selected: React.PropTypes.any.isRequired,
   onChange: React.PropTypes.func.isRequired,
   className: PropTypes.string,
-  data: PropTypes.arrayOf(RadioGroup.optionSchema).isRequired
+  data: PropTypes.arrayOf(RadioGroup.optionSchema).isRequired,
+  styles: PropTypes.object
 }

--- a/components/Selector.jsx
+++ b/components/Selector.jsx
@@ -1,13 +1,18 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/selector.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/selector.scss'
 import Checkmark from './icons/Checkmark'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function Selector (props) {
-  const { selected, onChange, className, data, ...remainingProps } = props
+export default function Selector ({
+  selected,
+  onChange,
+  className,
+  data,
+  styles,
+  ...remainingProps
+}) {
   const baseClass = 'cui__selector--direct'
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames(baseClass, 'title', className)
 
   const options = data.map((d) => {
@@ -40,5 +45,6 @@ Selector.propTypes = {
   selected: React.PropTypes.any.isRequired,
   onChange: React.PropTypes.func.isRequired,
   className: PropTypes.string,
-  data: PropTypes.arrayOf(Selector.optionSchema).isRequired
+  data: PropTypes.arrayOf(Selector.optionSchema).isRequired,
+  styles: PropTypes.object
 }

--- a/components/Switch.jsx
+++ b/components/Switch.jsx
@@ -1,8 +1,6 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/switch.scss'
-
-const classNames = classNamesBind.bind(styles)
+import defaultStyles from '@klarna/ui-css-components/src/components/switch.scss'
 
 export default class Switch extends React.Component {
   constructor (props) {
@@ -41,12 +39,14 @@ export default class Switch extends React.Component {
       disabled,
       error,
       name,
+      styles,
       ...remainingProps } = this.props
 
     const {
       checked,
       pressed } = this.state
 
+    const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
     const cls = classNames('cui__switch', {
       'is-checked': checked,
       'is-pressed': pressed,
@@ -91,5 +91,6 @@ Switch.propTypes = {
   name: PropTypes.string,
   align: PropTypes.oneOf(Switch.alignments),
   design: PropTypes.oneOf(Switch.designs),
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  styles: PropTypes.object
 }

--- a/components/Tooltip.jsx
+++ b/components/Tooltip.jsx
@@ -1,10 +1,9 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/tooltip.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/tooltip.scss'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function Tooltip ({ className, arrow, children, border }) {
+export default function Tooltip ({ className, arrow, children, border, styles }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames('cui__tooltip', arrow, className, { border })
 
   return (
@@ -25,5 +24,6 @@ Tooltip.propTypes = {
   className: PropTypes.string,
   arrow: PropTypes.oneOf(Tooltip.arrows),
   children: PropTypes.node,
-  border: PropTypes.bool
+  border: PropTypes.bool,
+  styles: PropTypes.object
 }

--- a/components/texts/Amount.jsx
+++ b/components/texts/Amount.jsx
@@ -1,11 +1,10 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/text.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/text.scss'
 import palette from './palette'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function Amount ({ children, className, color, ...remainingProps }) {
+export default function Amount ({ children, className, color, styles, ...remainingProps }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames('cui__amount-text', color, className)
 
   return (
@@ -16,11 +15,13 @@ export default function Amount ({ children, className, color, ...remainingProps 
 }
 
 Amount.defaultProps = {
-  color: 'black'
+  color: 'black',
+  styles: {}
 }
 
 Amount.propTypes = {
   color: PropTypes.oneOf(palette),
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  styles: PropTypes.object
 }

--- a/components/texts/Paragraph.jsx
+++ b/components/texts/Paragraph.jsx
@@ -1,11 +1,10 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/text.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/text.scss'
 import palette from './palette'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function Paragraph ({ children, className, color, condensed, design, ...props }) {
+export default function Paragraph ({ children, className, color, condensed, design, styles, ...props }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })  
   const cls = classNames(`cui__paragraph--${design}`, color, className, { condensed })
 
   return (
@@ -20,7 +19,8 @@ Paragraph.designs = ['primary', 'secondary', 'legal']
 Paragraph.defaultProps = {
   color: undefined,
   condensed: false,
-  design: 'primary'
+  design: 'primary',
+  styles: {}
 }
 
 Paragraph.propTypes = {
@@ -28,5 +28,6 @@ Paragraph.propTypes = {
   className: PropTypes.string,
   color: PropTypes.oneOf(palette),
   condensed: PropTypes.bool,
-  design: PropTypes.oneOf(Paragraph.designs)
+  design: PropTypes.oneOf(Paragraph.designs),
+  styles: PropTypes.object
 }

--- a/components/texts/Paragraph.jsx
+++ b/components/texts/Paragraph.jsx
@@ -4,7 +4,7 @@ import defaultStyles from '@klarna/ui-css-components/src/components/text.scss'
 import palette from './palette'
 
 export default function Paragraph ({ children, className, color, condensed, design, styles, ...props }) {
-  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })  
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames(`cui__paragraph--${design}`, color, className, { condensed })
 
   return (

--- a/components/texts/PrimaryTitle.jsx
+++ b/components/texts/PrimaryTitle.jsx
@@ -1,11 +1,11 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/text.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/text.scss'
 import palette from './palette'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function PrimaryTitle ({ className, color, small, strong, children, ...props }) {
+export default function PrimaryTitle ({ className, color, small, strong, children, styles, ...props }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+  
   const cls = classNames('cui__title--primary', color, className, {
     small,
     strong
@@ -21,7 +21,8 @@ export default function PrimaryTitle ({ className, color, small, strong, childre
 PrimaryTitle.defaultProps = {
   color: 'black',
   small: false,
-  strong: false
+  strong: false,
+  styles: {}
 }
 
 PrimaryTitle.propTypes = {
@@ -29,5 +30,6 @@ PrimaryTitle.propTypes = {
   className: PropTypes.string,
   color: PropTypes.oneOf(palette),
   small: PropTypes.bool,
-  strong: PropTypes.bool
+  strong: PropTypes.bool,
+  styles: PropTypes.object
 }

--- a/components/texts/PrimaryTitle.jsx
+++ b/components/texts/PrimaryTitle.jsx
@@ -5,7 +5,7 @@ import palette from './palette'
 
 export default function PrimaryTitle ({ className, color, small, strong, children, styles, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
-  
+
   const cls = classNames('cui__title--primary', color, className, {
     small,
     strong

--- a/components/texts/SecondaryTitle.jsx
+++ b/components/texts/SecondaryTitle.jsx
@@ -5,7 +5,7 @@ import palette from './palette'
 
 export default function SecondaryTitle ({ className, color, condensed, children, styles, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
-  
+
   const cls = classNames('cui__title--secondary', color, className, { condensed })
 
   return (

--- a/components/texts/SecondaryTitle.jsx
+++ b/components/texts/SecondaryTitle.jsx
@@ -1,11 +1,11 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/text.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/text.scss'
 import palette from './palette'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function SecondaryTitle ({ className, color, condensed, children, ...props }) {
+export default function SecondaryTitle ({ className, color, condensed, children, styles, ...props }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+  
   const cls = classNames('cui__title--secondary', color, className, { condensed })
 
   return (
@@ -17,12 +17,14 @@ export default function SecondaryTitle ({ className, color, condensed, children,
 
 SecondaryTitle.defaultProps = {
   color: 'black',
-  condensed: false
+  condensed: false,
+  styles: {}
 }
 
 SecondaryTitle.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   color: PropTypes.oneOf(palette),
-  condensed: PropTypes.bool
+  condensed: PropTypes.bool,
+  styles: PropTypes.object
 }

--- a/components/texts/Subtitle.jsx
+++ b/components/texts/Subtitle.jsx
@@ -5,7 +5,7 @@ import palette from './palette'
 
 export default function Subtitle ({ children, className, color, condensed, styles, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
-  
+
   const cls = classNames('cui__subtitle', color, className, { condensed })
 
   return (

--- a/components/texts/Subtitle.jsx
+++ b/components/texts/Subtitle.jsx
@@ -1,11 +1,11 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/text.scss'
+import defaultStyles from '@klarna/ui-css-components/src/components/text.scss'
 import palette from './palette'
 
-const classNames = classNamesBind.bind(styles)
-
-export default function Subtitle ({ children, className, color, condensed, ...props }) {
+export default function Subtitle ({ children, className, color, condensed, styles, ...props }) {
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
+  
   const cls = classNames('cui__subtitle', color, className, { condensed })
 
   return (
@@ -17,11 +17,13 @@ export default function Subtitle ({ children, className, color, condensed, ...pr
 
 Subtitle.defaultProps = {
   color: 'black',
-  condensed: false
+  condensed: false,
+  styles: {}
 }
 
 Subtitle.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
-  color: PropTypes.oneOf(palette)
+  color: PropTypes.oneOf(palette),
+  styles: PropTypes.object
 }

--- a/components/texts/TextLabel.jsx
+++ b/components/texts/TextLabel.jsx
@@ -1,15 +1,15 @@
 import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
-import styles from '@klarna/ui-css-components/src/components/text.scss'
-
-const classNames = classNamesBind.bind(styles)
+import defaultStyles from '@klarna/ui-css-components/src/components/text.scss'
 
 export default function TextLabel (props) {
   const {
     className,
     children,
+    styles,
     ...remainingProps } = props
 
+  const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames('cui__text-label', className)
 
   return (
@@ -17,7 +17,12 @@ export default function TextLabel (props) {
   )
 }
 
+TextLabel.defaultProps = {
+  styles: {}
+}
+
 TextLabel.propTypes = {
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  styles: PropTypes.object
 }

--- a/components/texts/TextLabel.jsx
+++ b/components/texts/TextLabel.jsx
@@ -2,13 +2,12 @@ import React, { PropTypes } from 'react'
 import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/text.scss'
 
-export default function TextLabel (props) {
-  const {
-    className,
-    children,
-    styles,
-    ...remainingProps } = props
-
+export default function TextLabel ({
+  className,
+  children,
+  styles,
+  ...remainingProps
+}) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
   const cls = classNames('cui__text-label', className)
 

--- a/tests/Checklist.spec.jsx
+++ b/tests/Checklist.spec.jsx
@@ -18,7 +18,6 @@ describe('Checklist', () => {
     const checklist = renderChecklist(
       {},
       items.map((item, index) =>
-        (console.log(index), true) &&
         renderChecklistItem({ key: index }, item))
     )
 


### PR DESCRIPTION
The purpose of this feature is to allow simple style overrides in a similar way to https://github.com/pluralsight/react-styleable overrides are done. The current approach with `className` is not flexible enough if a complex restyling is desired, and also falls short because of selector specificity that makes it hard to override the custom styles (having to resort to `!important`). See discussion in https://github.com/klarna/ui-css-components/issues/20

This PR is first to get feedback on the approach, if you think it's a good idea we can implement in all the components. 

Ping to @Deschtex who came up with the implementation.