### PR TITLE
Add legal size for text in the Switch component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY=test
+.PHONY: test
 
 lint:
 	npm run lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY=test
+
+lint:
+	npm run lint
+
+dev:
+	npm start
+
+test:
+	npm test

--- a/components/Switch.jsx
+++ b/components/Switch.jsx
@@ -40,6 +40,7 @@ export default class Switch extends React.Component {
       design,
       disabled,
       error,
+      legal,
       name,
       ...remainingProps } = this.props
 
@@ -53,7 +54,8 @@ export default class Switch extends React.Component {
       'is-disabled': disabled,
       'is-error': error,
       'right': align === 'right',
-      'checkbox': design === 'checkbox'
+      'checkbox': design === 'checkbox',
+      legal
     }, className)
 
     return (
@@ -79,7 +81,8 @@ Switch.defaultProps = {
   checked: false,
   error: false,
   disabled: false,
-  align: 'left'
+  align: 'left',
+  legal: false
 }
 
 Switch.propTypes = {
@@ -88,6 +91,7 @@ Switch.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   error: PropTypes.bool,
+  legal: PropTypes.bool,
   name: PropTypes.string,
   align: PropTypes.oneOf(Switch.alignments),
   design: PropTypes.oneOf(Switch.designs),

--- a/example/Switches.jsx
+++ b/example/Switches.jsx
@@ -38,6 +38,11 @@ export default function Switches () {
         <Switch design='checkbox'>This is a toggle switch with checkbox design</Switch>
       </Code>
 
+      <h5>Checkbox with legal size text</h5>
+      <Code>
+        <Switch design='checkbox' legal>This is a toggle switch with checkbox design and legal size text that usually will fold into multiple lines</Switch>
+      </Code>
+
       <h5>In a form</h5>
       <Code>
         <form onSubmit={(event) => {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "author": "Klarna front end people",
   "dependencies": {
-    "@klarna/ui-css-components": "6.1.1",
+    "@klarna/ui-css-components": "6.4.0",
     "classnames": "^2.1.3"
   },
   "peerDependencies": {

--- a/tests/Switch.spec.jsx
+++ b/tests/Switch.spec.jsx
@@ -137,4 +137,12 @@ describe('Switch', () => {
       equal(_switch.props.onMouseDown, false)
     })
   })
+
+  describe('legal', () => {
+    const _switch = render({ legal: true }, 'Toggle me')
+
+    it("has class 'legal'", () => {
+      ok(_switch.props.className.match('legal'))
+    })
+  })
 })


### PR DESCRIPTION
Also adds Makefile

<img width="611" alt="screen shot 2016-05-24 at 09 43 41" src="https://cloud.githubusercontent.com/assets/381614/15496143/0b45c2f4-2194-11e6-989d-69a1e46f5c18.png">
