### PR TITLE
Support className prop for icons

### DIFF
--- a/components/icons/AccountActivated.jsx
+++ b/components/icons/AccountActivated.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function AccountActivated ({ color, styles, ...props }) {
+export default function AccountActivated ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'big', color)}
+      className={classNames('cui__illustration', 'big', color, className)}
       viewBox='0 0 100 100'
       {...props}>
       <g transform='translate(28, 14)'>

--- a/components/icons/AllSet.jsx
+++ b/components/icons/AllSet.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function AllSet ({ color, styles, ...props }) {
+export default function AllSet ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'big', color)}
+      className={classNames('cui__illustration', 'big', color, className)}
       viewBox='0 0 100 100'
       {...props}>
       <g

--- a/components/icons/Arrow.jsx
+++ b/components/icons/Arrow.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Arrow ({ color, styles, ...props }) {
+export default function Arrow ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 21 21'
       {...props}>
       <path

--- a/components/icons/Cancel.jsx
+++ b/components/icons/Cancel.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Cancel ({ color, styles, ...props }) {
+export default function Cancel ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 21 21'
       {...props}>
       <circle

--- a/components/icons/Checkmark.jsx
+++ b/components/icons/Checkmark.jsx
@@ -3,14 +3,14 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Checkmark ({ color, styles, ...props }) {
+export default function Checkmark ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
       strokeLinecap='round'
       strokeWidth='2'
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 25 25'
       {...props}>
       <path

--- a/components/icons/Details.jsx
+++ b/components/icons/Details.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Details ({ color, styles, ...props }) {
+export default function Details ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 22 22'
       {...props}>
       <g

--- a/components/icons/Done.jsx
+++ b/components/icons/Done.jsx
@@ -4,12 +4,12 @@ import defaultStyles from '@klarna/ui-css-components/src/components/illustration
 import colors from './constants/colors'
 import Circle from './parts/Circle.jsx'
 
-export default function Done ({ color, styles, ...props }) {
+export default function Done ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'big', color)}
+      className={classNames('cui__illustration', 'big', color, className)}
       strokeWidth='2'
       strokeLinecap='round'
       viewBox='0 0 100 100'

--- a/components/icons/Download.jsx
+++ b/components/icons/Download.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Download ({ color, styles, ...props }) {
+export default function Download ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 22 22'
       {...props}>
       <g

--- a/components/icons/Error.jsx
+++ b/components/icons/Error.jsx
@@ -4,12 +4,12 @@ import defaultStyles from '@klarna/ui-css-components/src/components/illustration
 import colors from './constants/colors'
 import Circle from './parts/Circle.jsx'
 
-export default function Error ({ color, styles, ...props }) {
+export default function Error ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'big', color)}
+      className={classNames('cui__illustration', 'big', color, className)}
       strokeWidth='2'
       viewBox='0 0 100 100'
       {...props}>

--- a/components/icons/ExtendDate.jsx
+++ b/components/icons/ExtendDate.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function ExtendDate ({ color, styles, ...props }) {
+export default function ExtendDate ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 22 22'
       {...props}>
       <g

--- a/components/icons/Items.jsx
+++ b/components/icons/Items.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Items ({ color, styles, ...props }) {
+export default function Items ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       strokeLinecap='round'
       viewBox='0 0 22 22'
       {...props}>

--- a/components/icons/Letter.jsx
+++ b/components/icons/Letter.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Letter ({ color, styles, ...props }) {
+export default function Letter ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'big', color)}
+      className={classNames('cui__illustration', 'big', color, className)}
       viewBox='0 0 100 100'
       strokeWidth='2'
       {...props}>

--- a/components/icons/Logout.jsx
+++ b/components/icons/Logout.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Logout ({ color, styles, ...props }) {
+export default function Logout ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 21 21'
       {...props}>
       <g

--- a/components/icons/Mail.jsx
+++ b/components/icons/Mail.jsx
@@ -3,13 +3,13 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Mail ({ color, styles, ...props }) {
+export default function Mail ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
       strokeWidth='5'
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 100 100'
       {...props}>
       <g className={classNames('cui__illustration__stroke')}>

--- a/components/icons/NotFound.jsx
+++ b/components/icons/NotFound.jsx
@@ -4,12 +4,12 @@ import defaultStyles from '@klarna/ui-css-components/src/components/illustration
 import colors from './constants/colors'
 import File from './parts/File.jsx'
 
-export default function NotFound ({ color, styles, ...props }) {
+export default function NotFound ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'big', color)}
+      className={classNames('cui__illustration', 'big', color, className)}
       viewBox='0 0 100 100'
       {...props}>
       <g

--- a/components/icons/OpenLetter.jsx
+++ b/components/icons/OpenLetter.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function OpenLetter ({ color, styles, ...props }) {
+export default function OpenLetter ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'big', color)}
+      className={classNames('cui__illustration', 'big', color, className)}
       viewBox='0 0 100 100'
       {...props}>
       <g

--- a/components/icons/PadLock.jsx
+++ b/components/icons/PadLock.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function PadLock ({ color, styles, ...props }) {
+export default function PadLock ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'big', color)}
+      className={classNames('cui__illustration', 'big', color, className)}
       viewBox='0 0 100 100'
       {...props}>
       <g

--- a/components/icons/Password.jsx
+++ b/components/icons/Password.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Password ({ color, styles, ...props }) {
+export default function Password ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 100 100'
       strokeWidth='5'
       {...props}>

--- a/components/icons/Person.jsx
+++ b/components/icons/Person.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Person ({ color, styles, ...props }) {
+export default function Person ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 21 21'
       {...props}>
       <circle

--- a/components/icons/Phone.jsx
+++ b/components/icons/Phone.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Phone ({ color, styles, ...props }) {
+export default function Phone ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 21 21'
       {...props}>
       <g

--- a/components/icons/Question.jsx
+++ b/components/icons/Question.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Question ({ color, styles, ...props }) {
+export default function Question ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 21 21'
       {...props}>
       <circle

--- a/components/icons/Remind.jsx
+++ b/components/icons/Remind.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Remind ({ color, styles, ...props }) {
+export default function Remind ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'tiny', color)}
+      className={classNames('cui__illustration', 'tiny', color, className)}
       viewBox='0 0 22 22'
       {...props}>
       <g

--- a/components/icons/SMS.jsx
+++ b/components/icons/SMS.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function SMS ({ color, styles, ...props }) {
+export default function SMS ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'big', color)}
+      className={classNames('cui__illustration', 'big', color, className)}
       viewBox='0 0 100 100'
       {...props}>
       <g

--- a/components/icons/Time.jsx
+++ b/components/icons/Time.jsx
@@ -4,12 +4,12 @@ import defaultStyles from '@klarna/ui-css-components/src/components/illustration
 import colors from './constants/colors'
 import Circle from './parts/Circle.jsx'
 
-export default function Time ({ color, styles, ...props }) {
+export default function Time ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'big', color)}
+      className={classNames('cui__illustration', 'big', color, className)}
       strokeLinecap='round'
       strokeWidth='2'
       viewBox='0 0 100 100'

--- a/components/icons/Warning.jsx
+++ b/components/icons/Warning.jsx
@@ -3,12 +3,12 @@ import classNamesBind from 'classnames/bind'
 import defaultStyles from '@klarna/ui-css-components/src/components/illustration.scss'
 import colors from './constants/colors'
 
-export default function Warning ({ color, styles, ...props }) {
+export default function Warning ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'big', color)}
+      className={classNames('cui__illustration', 'big', color, className)}
       viewBox='0 0 100 100'
       {...props}>
       <g

--- a/components/icons/Wrong.jsx
+++ b/components/icons/Wrong.jsx
@@ -4,12 +4,12 @@ import defaultStyles from '@klarna/ui-css-components/src/components/illustration
 import colors from './constants/colors'
 import File from './parts/File.jsx'
 
-export default function Wrong ({ color, styles, ...props }) {
+export default function Wrong ({ color, styles, className, ...props }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   return (
     <svg
-      className={classNames('cui__illustration', 'big', color)}
+      className={classNames('cui__illustration', 'big', color, className)}
       viewBox='0 0 100 100'
       {...props}>
       <g


### PR DESCRIPTION
For instance, fixing selector:
before:
![image](https://cloud.githubusercontent.com/assets/2931327/16378700/fcec7458-3c75-11e6-8017-6d0543b5a5ef.png)


after:
![image](https://cloud.githubusercontent.com/assets/2931327/16378653/aa2447c8-3c75-11e6-95fa-87d29abc6d30.png)

We still need to fix ```KlarnaLogo``` which uses deleted file ```Icon.jsx```