### PR TITLE
Spread props in options

### DIFF
--- a/components/Dropdown.jsx
+++ b/components/Dropdown.jsx
@@ -81,9 +81,9 @@ export default class Dropdown extends Component {
           {...props}
         >
           {
-            options && options.map(({ label, value }) => (
-              <option key={value} value={value}>
-                {label}
+            options && options.map((attributes) => (
+              <option key={attributes.value} {...attributes}>
+                {attributes.label}
               </option>
             ))
           }


### PR DESCRIPTION
We need to spread the props to use attributes like "hidden" and "disabled" on the options.