### PR TITLE
Move the global declaration to config instead of inline

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,11 @@
     "webpack-dev-server": "^1.12.1",
     "webpack-error-notification": "^0.1.6",
     "yargs": "^3.31.0"
+  },
+  "standard": {
+    "globals": [
+      "describe",
+      "it"
+    ]
   }
 }

--- a/tests/Amount.spec.jsx
+++ b/tests/Amount.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Amount from '../components/texts/Amount'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Button.spec.jsx
+++ b/tests/Button.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Button from '../components/Button'
 import { ok, equal, deepEqual } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Checklist.spec.jsx
+++ b/tests/Checklist.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Checklist from '../components/Checklist'
 import { equal, ok } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Dialog.spec.jsx
+++ b/tests/Dialog.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Dialog from '../components/Dialog'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Dropdown.spec.jsx
+++ b/tests/Dropdown.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Dropdown from '../components/Dropdown'
 import { equal, ok } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Field.spec.jsx
+++ b/tests/Field.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Field from '../components/Field'
 import { equal, ok } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Fieldset.spec.jsx
+++ b/tests/Fieldset.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Fieldset from '../components/Fieldset'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Input.spec.jsx
+++ b/tests/Input.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Input from '../components/Input'
 import assert, { equal } from 'assert'
 import { renderer, shallow } from './helpers'

--- a/tests/Label.spec.jsx
+++ b/tests/Label.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Label from '../components/Label'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Link.spec.jsx
+++ b/tests/Link.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Link from '../components/Link'
 import { equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Loader.spec.jsx
+++ b/tests/Loader.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Loader from '../components/Loader'
 import { equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Menu.spec.jsx
+++ b/tests/Menu.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Menu from '../components/Menu'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Paragraph.spec.jsx
+++ b/tests/Paragraph.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Paragraph from '../components/texts/Paragraph'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/PayButton.spec.jsx
+++ b/tests/PayButton.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import PayButton from '../components/PayButton'
 import Button from '../components/Button'
 import { ok, equal } from 'assert'

--- a/tests/Preview.spec.jsx
+++ b/tests/Preview.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Preview, { PreviewTitle, PreviewLink } from '../components/Preview'
 import { equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/PrimaryTitle.spec.jsx
+++ b/tests/PrimaryTitle.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import PrimaryTitle from '../components/texts/PrimaryTitle'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/RadioGroup.spec.jsx
+++ b/tests/RadioGroup.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import RadioGroup from '../components/RadioGroup'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/SecondaryTitle.spec.jsx
+++ b/tests/SecondaryTitle.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import SecondaryTitle from '../components/texts/SecondaryTitle'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Selector.spec.jsx
+++ b/tests/Selector.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Selector from '../components/Selector'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Subtitle.spec.jsx
+++ b/tests/Subtitle.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Subtitle from '../components/texts/Subtitle'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Switch.spec.jsx
+++ b/tests/Switch.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Switch from '../components/Switch'
 import { ok, equal } from 'assert'
 import { renderer, shallow } from './helpers'

--- a/tests/TextLabel.spec.jsx
+++ b/tests/TextLabel.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import TextLabel from '../components/texts/TextLabel'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/Tooltip.spec.jsx
+++ b/tests/Tooltip.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import Tooltip from '../components/Tooltip'
 import { ok, equal } from 'assert'
 import { renderer } from './helpers'

--- a/tests/decorators/statefulFocus.spec.jsx
+++ b/tests/decorators/statefulFocus.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import React, { Component } from 'react'
 import statefulFocus from '../../lib/decorators/statefulFocus'
 import { shallow } from '../helpers'

--- a/tests/decorators/statefulValue.spec.jsx
+++ b/tests/decorators/statefulValue.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import React, { Component } from 'react'
 import statefulValue from '../../lib/decorators/statefulValue'
 import { shallow } from '../helpers'

--- a/tests/describePalette.es6
+++ b/tests/describePalette.es6
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import { ok } from 'assert'
 import palette from '../components/texts/palette'
 

--- a/tests/propTypes/fieldSizeFraction.spec.es6
+++ b/tests/propTypes/fieldSizeFraction.spec.es6
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import fieldSizeFraction, { FIELD_SIZE_ERRORS } from '../../propTypes/fieldSizeFraction'
 import { equal } from 'assert'
 

--- a/tests/propTypes/validateSize.spec.es6
+++ b/tests/propTypes/validateSize.spec.es6
@@ -1,5 +1,3 @@
-/* global describe it */
-
 import validateSize from '../../propTypes/validateSize'
 import assert, { ok } from 'assert'
 

--- a/tests/uncontrolled/RadioGroup.spec.jsx
+++ b/tests/uncontrolled/RadioGroup.spec.jsx
@@ -1,5 +1,3 @@
-/* global describe it */
-
 /*
  * The default behaviour here is defined by
  * RadioGroup, so the tests focus on


### PR DESCRIPTION
This way you don't have to manually add the exception for `describe` and `it` in every single spec file.