### PR TITLE
Fix position of loader in button

### DIFF
--- a/components/Button.jsx
+++ b/components/Button.jsx
@@ -77,7 +77,7 @@ Button.propTypes = {
 
 const renderButton = (content, classNames, disabled, loading, loaderColor, remainingProps) => (
   <button className={classNames} disabled={disabled} {...remainingProps}>
-    {loading ? <Loader color={loaderColor}/> : content}
+    {loading ? <Loader inline color={loaderColor}/> : content}
   </button>
 )
 
@@ -88,7 +88,7 @@ const renderDynamicallyStyledPrimaryButton = (content, classNames, labelClassNam
     borderColor: backgroundColor
   }}>
     <span className={labelClassNames.label}>
-      {loading ? <Loader color={loaderColor}/> : content}
+      {loading ? <Loader inline color={loaderColor}/> : content}
     </span>
   </button>
 )
@@ -100,7 +100,7 @@ const renderDynamicallyStyledSecondaryButton = (content, classNames, labelClassN
     borderColor: backgroundColor
   }}>
     <div className={labelClassNames.label}>
-      {loading ? <Loader color={loaderColor}/> : content}
+      {loading ? <Loader inline color={loaderColor}/> : content}
       {
         disabled ||
           <span

--- a/components/Loader/index.jsx
+++ b/components/Loader/index.jsx
@@ -26,7 +26,7 @@ const gradients = [
   {x1: '0', y1: '0', x2: '1', y2: '1'}
 ]
 
-export default function Loader ({ className, color, size, styles }) {
+export default function Loader ({ className, color, inline, size, styles }) {
   const classNames = classNamesBind.bind({ ...defaultStyles, ...styles })
 
   const _color = Array.isArray(color) ? color : colors[color] || colors.default
@@ -38,7 +38,7 @@ export default function Loader ({ className, color, size, styles }) {
   const corner = _size * 0.433
 
   return (
-    <svg width={_size} height={_size} className={classNames('loader', className)} viewBox={`-1 -1 ${_size + stroke} ${_size + stroke}`}>
+    <svg width={_size} height={_size} className={classNames('loader', className, { inline })} viewBox={`-1 -1 ${_size + stroke} ${_size + stroke}`}>
       <defs>
         {
           gradients.map((props, index) => (
@@ -67,6 +67,7 @@ Loader.propTypes = {
     PropTypes.oneOf(Object.keys(colors)),
     PropTypes.array
   ]),
+  inline: PropTypes.bool,
   size: PropTypes.oneOf(Object.keys(sizes)),
   styles: PropTypes.object
 }

--- a/components/Loader/styles.scss
+++ b/components/Loader/styles.scss
@@ -10,5 +10,5 @@
 }
 
 .inline {
-  display: inline-block;
+  margin: 0 auto;
 }

--- a/components/Loader/styles.scss
+++ b/components/Loader/styles.scss
@@ -8,3 +8,7 @@
     display: block;
     margin: 0;
 }
+
+.inline {
+  display: inline-block;
+}

--- a/example/Loaders.jsx
+++ b/example/Loaders.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Loader from '../components/Loader'
-import { SecondaryTitle } from '../components/Text'
+import { SecondaryTitle, Subtitle } from '../components/Text'
 import Code from './Code'
 
 export default function Loaders () {
@@ -12,6 +12,12 @@ export default function Loaders () {
         <Loader />
         <Loader size='small' />
         <Loader size='tiny' />
+      </Code>
+
+      <Subtitle>Inline</Subtitle>
+      <Code>
+        <Loader inline />
+        <Loader inline />
       </Code>
 
       <SecondaryTitle color='blue' margins>Secondary</SecondaryTitle>

--- a/tests/Button.spec.jsx
+++ b/tests/Button.spec.jsx
@@ -74,6 +74,10 @@ describe('Button', () => {
       it('is of type loader', () => {
         equal(button.props.children.type, Loader)
       })
+
+      it('is inline', () => {
+        equal(button.props.children.props.inline, true)
+      })
     })
   })
 
@@ -142,6 +146,10 @@ describe('Button', () => {
 
           it('is of type Loader', () => {
             equal(loader.type, Loader)
+          })
+
+          it('is inline', () => {
+            equal(loader.props.inline, true)
           })
 
           it('has the color of the text', () => {
@@ -219,6 +227,10 @@ describe('Button', () => {
 
           it('is of type Loader', () => {
             equal(loader.type, Loader)
+          })
+
+          it('is inline', () => {
+            equal(loader.props.inline, true)
           })
 
           it('has the color of the background', () => {

--- a/tests/Loader.spec.jsx
+++ b/tests/Loader.spec.jsx
@@ -1,7 +1,7 @@
 /* global describe it */
 
 import Loader from '../components/Loader'
-import { equal } from 'assert'
+import { equal, ok } from 'assert'
 import { renderer } from './helpers'
 
 const render = renderer(Loader)
@@ -23,6 +23,14 @@ describe('Loader', () => {
     const loader = render({ className: 'custom' })
 
     equal('loader custom', loader.props.className)
+  })
+
+  describe('inline', () => {
+    const loader = render({ inline: true })
+
+    it('has class "inline"', () => {
+      ok(loader.props.className.match('inline'))
+    })
   })
 
   describe('size', () => {


### PR DESCRIPTION
<img width="587" alt="screen shot 2016-07-12 at 10 28 00" src="https://cloud.githubusercontent.com/assets/381614/16760302/55001018-481b-11e6-9a47-113c3e7ded04.png">

Now, no matter how wide the loader is, it will always be centered.